### PR TITLE
Don't use the old cli config file for the mgmt cli

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,8 +106,8 @@ func RootInitConfig() {
 				fmt.Println("Using config file:", viper.ConfigFileUsed())
 			}
 
-			viper.SetConfigFile(tapir.DefaultTapirCliCfgFile)
-			viper.AutomaticEnv() // read in environment variables that match
+			//viper.SetConfigFile(tapir.DefaultTapirCliCfgFile)
+			//viper.AutomaticEnv() // read in environment variables that match
 
 			// If a config file is found, read it in.
 			if err := viper.MergeInConfig(); err != nil {


### PR DESCRIPTION
Denna fil ska vi väl inte behöva längre för mgmt-verktyget?